### PR TITLE
Skip polyfill for supported PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,10 @@
         "sensiolabs/behat-page-object-extension": "~2.0@rc",
         "symfony/phpunit-bridge": "^3.0"
     },
+    "replace": {
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*"
+    },
     "autoload": {
         "psr-4": {
             "ParkManager\\": "src/"


### PR DESCRIPTION
|Q            |A      |
|---          |---    |
|Bug Fix?     |no     |
|New Feature? |yes    |
|BC Breaks?   |no     |
|Deprecations?|no     |
|Fixed Tickets|       |
|License      |MPL-2.0|
                       

Skip polyfill for supported PHP versions, this speeds-up the runtime a little bit.
Not sure if this this work, but we can at least try 🤘