### PR TITLE
Rename getX methods that return null to findX

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,27 @@
 UPGRADE
 =======
 
+## Upgrade FROM 0.2.0 to 0.3.0
+
+### User
+
+ * The `UserCollection::getByEmailAddress()` method has been renamed 
+   to `findByEmailAddress`.
+
+ * The `UserCollection::getByEmailAddressChangeToken()` method has been renamed 
+   to `findByEmailAddressChangeToken`.
+
+ * The `UserCollection::getByPasswordResetToken()` method has been renamed 
+   to `findByPasswordResetToken`.
+  
+### Webhosting
+
+* The `WebhostingAccountOwner` class has been replaced by `RootEntityOwner` 
+  of the Model Component.
+  
+* The `Model\DomainName\WebhostingDomainNameRepository::getByFullName()` method has
+  been renamed to `findByFullName`.
+
 ## Upgrade FROM 0.1.0 to 0.2.0
 
 ### Model

--- a/src/Bundle/UserBundle/Model/DoctrineOrmUserCollection.php
+++ b/src/Bundle/UserBundle/Model/DoctrineOrmUserCollection.php
@@ -24,6 +24,8 @@ use ParkManager\Component\User\Model\UserId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ *
+ * @method User findOneBy(array $criteria, array $orderBy = null)
  */
 class DoctrineOrmUserCollection extends EntityRepository implements UserCollection
 {
@@ -65,12 +67,12 @@ class DoctrineOrmUserCollection extends EntityRepository implements UserCollecti
         });
     }
 
-    public function getByEmailAddress(string $email): ?User
+    public function findByEmailAddress(string $email): ?User
     {
         return $this->findOneBy(['canonicalEmail' => $email]);
     }
 
-    public function getsByEmailAddressChangeToken(string $selector): ?User
+    public function findByEmailAddressChangeToken(string $selector): ?User
     {
         return $this->createQueryBuilder('u')
             ->where('u.emailAddressChangeToken.selector = :selector')
@@ -80,7 +82,7 @@ class DoctrineOrmUserCollection extends EntityRepository implements UserCollecti
         ;
     }
 
-    public function getByPasswordResetToken(string $selector): ?User
+    public function findByPasswordResetToken(string $selector): ?User
     {
         return $this->createQueryBuilder('u')
             ->where('u.passwordResetToken.selector = :selector')

--- a/src/Bundle/UserBundle/Tests/Action/ChangePasswordActionTestCase.php
+++ b/src/Bundle/UserBundle/Tests/Action/ChangePasswordActionTestCase.php
@@ -109,7 +109,7 @@ abstract class ChangePasswordActionTestCase extends WebTestCase
         /** @var \ParkManager\Component\User\Model\UserCollection $repository */
         $repository = $client->getContainer()->get($this->getRepositoryServiceId());
 
-        if (!$user = $repository->getByEmailAddress($this->getUsername())) {
+        if (!$user = $repository->findByEmailAddress($this->getUsername())) {
             $this->fail(sprintf('User with e-mail address %s is not registered. Are fixtures loaded?', $this->getUsername()));
         }
 

--- a/src/Component/Core/Model/AdministratorRepository.php
+++ b/src/Component/Core/Model/AdministratorRepository.php
@@ -21,8 +21,8 @@ use ParkManager\Component\User\Model\UserId;
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  *
  * @method get(UserId $id): Administrator
- * @method getByEmailAddress(string $email): Administrator
- * @method getsByEmailAddressChangeToken(string $selector): Administrator
+ * @method findByEmailAddress(string $email): Administrator
+ * @method findByEmailAddressChangeToken(string $selector): Administrator
  */
 interface AdministratorRepository extends UserCollection
 {

--- a/src/Component/Core/Model/Handler/RegisterAdministratorHandler.php
+++ b/src/Component/Core/Model/Handler/RegisterAdministratorHandler.php
@@ -39,7 +39,7 @@ final class RegisterAdministratorHandler
     {
         $canonicalEmail = $this->emailCanonicalizer->canonicalize($email = $command->email());
 
-        if (null !== $this->repository->getByEmailAddress($canonicalEmail)) {
+        if (null !== $this->repository->findByEmailAddress($canonicalEmail)) {
             throw new AdministratorEmailAddressAlreadyInUse();
         }
 

--- a/src/Component/Core/Tests/Model/Handler/RegisterUserHandlerTest.php
+++ b/src/Component/Core/Tests/Model/Handler/RegisterUserHandlerTest.php
@@ -68,7 +68,7 @@ final class RegisterUserHandlerTest extends TestCase
     private function expectUserSaved(RegisterAdministrator $command): UserCollection
     {
         $repository = $this->prophesize(UserCollection::class);
-        $repository->getByEmailAddress(Argument::any())->willReturn(null);
+        $repository->findByEmailAddress(Argument::any())->willReturn(null);
         $repository->save(Argument::that(function (Administrator $user) use ($command) {
             self::assertTrue($command->id()->equals($user->id()));
             self::assertEquals($command->email(), $user->email());
@@ -89,7 +89,7 @@ final class RegisterUserHandlerTest extends TestCase
         $userProphecy->id()->willReturn($this->existingId());
 
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByEmailAddress($email)->willReturn($userProphecy->reveal());
+        $repositoryProphecy->findByEmailAddress($email)->willReturn($userProphecy->reveal());
         $repositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $repositoryProphecy->reveal();

--- a/src/Component/User/Model/Handler/ConfirmEmailAddressChangeHandler.php
+++ b/src/Component/User/Model/Handler/ConfirmEmailAddressChangeHandler.php
@@ -35,7 +35,7 @@ final class ConfirmEmailAddressChangeHandler
         $token = $command->token();
         $success = false;
 
-        if (null !== ($user = $this->userCollection->getsByEmailAddressChangeToken($token->selector()))) {
+        if (null !== ($user = $this->userCollection->findByEmailAddressChangeToken($token->selector()))) {
             $success = $user->confirmEmailAddressChange($token);
 
             // Always save, as the token is cleared.

--- a/src/Component/User/Model/Handler/ConfirmUserPasswordResetHandler.php
+++ b/src/Component/User/Model/Handler/ConfirmUserPasswordResetHandler.php
@@ -35,7 +35,7 @@ final class ConfirmUserPasswordResetHandler
         $token = $command->token();
         $success = false;
 
-        if (null !== ($user = $this->userCollection->getByPasswordResetToken($token->selector()))) {
+        if (null !== ($user = $this->userCollection->findByPasswordResetToken($token->selector()))) {
             $success = $user->confirmPasswordReset($token, $command->password());
 
             // Always save, as the token is cleared.

--- a/src/Component/User/Model/Handler/RequestConfirmationOfEmailAddressChangeHandler.php
+++ b/src/Component/User/Model/Handler/RequestConfirmationOfEmailAddressChangeHandler.php
@@ -49,7 +49,7 @@ final class RequestConfirmationOfEmailAddressChangeHandler
     {
         $canonicalEmail = $command->canonicalEmail();
 
-        if (null !== $this->userCollection->getByEmailAddress($canonicalEmail)) {
+        if (null !== $this->userCollection->findByEmailAddress($canonicalEmail)) {
             // E-mail address is already in use by (another) user. To prevent exposing existence simply do nothing.
             // This also covers when the e-mail address was not actually changed.
             return;

--- a/src/Component/User/Model/Handler/RequestUserPasswordResetHandler.php
+++ b/src/Component/User/Model/Handler/RequestUserPasswordResetHandler.php
@@ -55,7 +55,7 @@ final class RequestUserPasswordResetHandler
         $email = $command->email();
         $canonicalEmail = $this->emailCanonicalizer->canonicalize($email);
 
-        if (null === ($user = $this->userCollection->getByEmailAddress($canonicalEmail))) {
+        if (null === ($user = $this->userCollection->findByEmailAddress($canonicalEmail))) {
             // No account with this e-mail address. To prevent exposing existence simply do nothing.
             return;
         }

--- a/src/Component/User/Model/UserCollection.php
+++ b/src/Component/User/Model/UserCollection.php
@@ -37,21 +37,21 @@ interface UserCollection
      *
      * @return User|null
      */
-    public function getByEmailAddress(string $email);
+    public function findByEmailAddress(string $email);
 
     /**
      * @param string $selector
      *
      * @return User|null
      */
-    public function getsByEmailAddressChangeToken(string $selector);
+    public function findByEmailAddressChangeToken(string $selector);
 
     /**
      * @param string $selector
      *
      * @return User|null
      */
-    public function getByPasswordResetToken(string $selector);
+    public function findByPasswordResetToken(string $selector);
 
     /**
      * Save the User in the repository.

--- a/src/Component/User/Tests/Model/Handler/ConfirmEmailAddressChangeHandlerTest.php
+++ b/src/Component/User/Tests/Model/Handler/ConfirmEmailAddressChangeHandlerTest.php
@@ -79,7 +79,7 @@ final class ConfirmEmailAddressChangeHandlerTest extends TestCase
     private function expectUserSaved(string $selector, User $user): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getsByEmailAddressChangeToken($selector)->willReturn($user);
+        $repositoryProphecy->findByEmailAddressChangeToken($selector)->willReturn($user);
         $repositoryProphecy->save($user)->shouldBeCalledTimes(1);
 
         return $repositoryProphecy->reveal();
@@ -88,7 +88,7 @@ final class ConfirmEmailAddressChangeHandlerTest extends TestCase
     private function expectUserNotSaved(): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getsByEmailAddressChangeToken(Argument::any())->willReturn(null);
+        $repositoryProphecy->findByEmailAddressChangeToken(Argument::any())->willReturn(null);
         $repositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $repositoryProphecy->reveal();

--- a/src/Component/User/Tests/Model/Handler/ConfirmUserPasswordResetHandlerTest.php
+++ b/src/Component/User/Tests/Model/Handler/ConfirmUserPasswordResetHandlerTest.php
@@ -82,7 +82,7 @@ final class ConfirmUserPasswordResetHandlerTest extends TestCase
     private function expectUserSaved(string $selector, User $user): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByPasswordResetToken($selector)->willReturn($user);
+        $repositoryProphecy->findByPasswordResetToken($selector)->willReturn($user);
         $repositoryProphecy->save($user)->shouldBeCalledTimes(1);
 
         return $repositoryProphecy->reveal();
@@ -91,7 +91,7 @@ final class ConfirmUserPasswordResetHandlerTest extends TestCase
     private function expectUserNotSaved(): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByPasswordResetToken(Argument::any())->willReturn(null);
+        $repositoryProphecy->findByPasswordResetToken(Argument::any())->willReturn(null);
         $repositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $repositoryProphecy->reveal();

--- a/src/Component/User/Tests/Model/Handler/RequestConfirmationOfEmailAddressChangeHandlerTest.php
+++ b/src/Component/User/Tests/Model/Handler/RequestConfirmationOfEmailAddressChangeHandlerTest.php
@@ -76,7 +76,7 @@ final class RequestConfirmationOfEmailAddressChangeHandlerTest extends TestCase
         $userProphecy->id()->willReturn($this->existingId());
 
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByEmailAddress($email)->willReturn($userProphecy->reveal());
+        $repositoryProphecy->findByEmailAddress($email)->willReturn($userProphecy->reveal());
         $repositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $repositoryProphecy->reveal();
@@ -85,7 +85,7 @@ final class RequestConfirmationOfEmailAddressChangeHandlerTest extends TestCase
     private function expectUserSaved(string $email, User $user): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByEmailAddress($email)->willReturn(null);
+        $repositoryProphecy->findByEmailAddress($email)->willReturn(null);
         $repositoryProphecy->get($user->id())->willReturn($user);
         $repositoryProphecy->save($user)->shouldBeCalledTimes(1);
 

--- a/src/Component/User/Tests/Model/Handler/RequestUserPasswordResetHandlerTest.php
+++ b/src/Component/User/Tests/Model/Handler/RequestUserPasswordResetHandlerTest.php
@@ -97,7 +97,7 @@ final class RequestUserPasswordResetHandlerTest extends TestCase
     private function expectUserNotSaved(string $email, ?User $user): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByEmailAddress($email)->willReturn($user);
+        $repositoryProphecy->findByEmailAddress($email)->willReturn($user);
         $repositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $repositoryProphecy->reveal();
@@ -106,7 +106,7 @@ final class RequestUserPasswordResetHandlerTest extends TestCase
     private function expectUserSaved(string $email, User $user): UserCollection
     {
         $repositoryProphecy = $this->prophesize(UserCollection::class);
-        $repositoryProphecy->getByEmailAddress($email)->willReturn($user);
+        $repositoryProphecy->findByEmailAddress($email)->willReturn($user);
         $repositoryProphecy->save($user)->shouldBeCalledTimes(1);
 
         return $repositoryProphecy->reveal();

--- a/src/Component/User/UPGRADE.md
+++ b/src/Component/User/UPGRADE.md
@@ -1,6 +1,17 @@
 UPGRADE
 =======
 
+## Upgrade FROM 0.2.0 to 0.3.0
+
+ * The `UserCollection::getByEmailAddress()` method has been renamed 
+   to `findByEmailAddress`.
+
+ * The `UserCollection::getByEmailAddressChangeToken()` method has been renamed 
+   to `findByEmailAddressChangeToken`.
+
+ * The `UserCollection::getByPasswordResetToken()` method has been renamed 
+   to `findByPasswordResetToken`.
+
 ## Upgrade FROM 0.1.0 to 0.2.0
 
 * The `UserIdTrait` was removed.

--- a/src/Module/Webhosting/Infrastructure/Doctrine/Repository/WebhostingDomainNameOrmRepository.php
+++ b/src/Module/Webhosting/Infrastructure/Doctrine/Repository/WebhostingDomainNameOrmRepository.php
@@ -104,7 +104,7 @@ final class WebhostingDomainNameOrmRepository extends EntityRepository implement
         }
     }
 
-    public function getByFullName(DomainName $name): ?WebhostingDomainName
+    public function findByFullName(DomainName $name): ?WebhostingDomainName
     {
         return $this->createQueryBuilder('d')
             ->where('d.domainName.name = :name AND d.domainName.tld = :tld')

--- a/src/Module/Webhosting/Model/Account/Handler/RegisterWebhostingAccountHandler.php
+++ b/src/Module/Webhosting/Model/Account/Handler/RegisterWebhostingAccountHandler.php
@@ -47,7 +47,7 @@ final class RegisterWebhostingAccountHandler
         $className = $this->accountRepository->getModelClass();
         $domainName = $command->domainName();
 
-        if (null !== $currentRegistration = $this->domainNameRepository->getByFullName($domainName)) {
+        if (null !== $currentRegistration = $this->domainNameRepository->findByFullName($domainName)) {
             throw DomainNameAlreadyInUse::byAccountId($domainName, $currentRegistration->account()->id());
         }
 

--- a/src/Module/Webhosting/Model/DomainName/WebhostingDomainNameRepository.php
+++ b/src/Module/Webhosting/Model/DomainName/WebhostingDomainNameRepository.php
@@ -42,9 +42,9 @@ interface WebhostingDomainNameRepository
     public function getPrimaryOf(WebhostingAccountId $id): WebhostingDomainName;
 
     /**
-     * Get the WebhostingDomainName registration by it's full name.
+     * Finds a WebhostingDomainName registration by it's full name.
      */
-    public function getByFullName(DomainName $name): ?WebhostingDomainName;
+    public function findByFullName(DomainName $name): ?WebhostingDomainName;
 
     /**
      * Save the WebhostingDomainName in the repository.

--- a/src/Module/Webhosting/Model/Package/WebhostingPackageRepository.php
+++ b/src/Module/Webhosting/Model/Package/WebhostingPackageRepository.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace ParkManager\Module\Webhosting\Model\Package;
 
-use ParkManager\Module\Webhosting\Model\Account\Exception\WebhostingAccountNotFound;
+use ParkManager\Module\Webhosting\Model\Package\Exception\WebhostingPackageNotFound;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
@@ -29,7 +29,7 @@ interface WebhostingPackageRepository
     public function getModelClass(): string;
 
     /**
-     * @throws WebhostingAccountNotFound when no account was found with the id
+     * @throws WebhostingPackageNotFound when no package was found with the id
      */
     public function get(WebhostingPackageId $id): WebhostingPackage;
 

--- a/src/Module/Webhosting/Tests/Infrastructure/Doctrine/Repository/WebhostingDomainNameOrmRepositoryTest.php
+++ b/src/Module/Webhosting/Tests/Infrastructure/Doctrine/Repository/WebhostingDomainNameOrmRepositoryTest.php
@@ -149,10 +149,10 @@ final class WebhostingDomainNameOrmRepositoryTest extends EntityRepositoryTestCa
     /** @test */
     public function it_gets_by_name()
     {
-        $domainName1 = $this->repository->getByFullName(new DomainName('example', 'com'));
-        $domainName2 = $this->repository->getByFullName(new DomainName('example', 'net'));
-        $domainName3 = $this->repository->getByFullName(new DomainName('example', 'co.uk'));
-        $domainName4 = $this->repository->getByFullName(new DomainName('example', 'noop'));
+        $domainName1 = $this->repository->findByFullName(new DomainName('example', 'com'));
+        $domainName2 = $this->repository->findByFullName(new DomainName('example', 'net'));
+        $domainName3 = $this->repository->findByFullName(new DomainName('example', 'co.uk'));
+        $domainName4 = $this->repository->findByFullName(new DomainName('example', 'noop'));
 
         self::assertNotNull($domainName1);
         self::assertNotNull($domainName2);

--- a/src/Module/Webhosting/Tests/Model/Account/Handler/RegisterWebhostingAccountHandlerTest.php
+++ b/src/Module/Webhosting/Tests/Model/Account/Handler/RegisterWebhostingAccountHandlerTest.php
@@ -159,7 +159,7 @@ final class RegisterWebhostingAccountHandlerTest extends TestCase
     {
         $domainNameRepositoryProphecy = $this->prophesize(WebhostingDomainNameRepository::class);
         $domainNameRepositoryProphecy->getModelClass()->willReturn(WebhostingDomainName::class);
-        $domainNameRepositoryProphecy->getByFullName($expectedDomain)->willReturn(null);
+        $domainNameRepositoryProphecy->findByFullName($expectedDomain)->willReturn(null);
         $domainNameRepositoryProphecy->save(
             Argument::that(
                 function (WebhostingDomainName $domain) use ($expectedDomain, $accountId) {
@@ -190,7 +190,7 @@ final class RegisterWebhostingAccountHandlerTest extends TestCase
 
         $domainNameRepositoryProphecy = $this->prophesize(WebhostingDomainNameRepository::class);
         $domainNameRepositoryProphecy->getModelClass()->willReturn(WebhostingDomainName::class);
-        $domainNameRepositoryProphecy->getByFullName($expectedDomain)->willReturn($existingDomain);
+        $domainNameRepositoryProphecy->findByFullName($expectedDomain)->willReturn($existingDomain);
         $domainNameRepositoryProphecy->save(Argument::any())->shouldNotBeCalled();
 
         return $domainNameRepositoryProphecy->reveal();

--- a/src/Module/Webhosting/UPGRADE.md
+++ b/src/Module/Webhosting/UPGRADE.md
@@ -3,6 +3,9 @@ UPGRADE
 
 ## Upgrade FROM 0.2.0 to 0.3.0
 
-* The `WebhostingAccountOwner` class has been replaced by `RootEntityOwner` 
-  of the Model Component.
+ * The `WebhostingAccountOwner` class has been replaced by `RootEntityOwner` 
+   of the Model Component.
+  
+ * The `Model\DomainName\WebhostingDomainNameRepository::getByFullName()` method has
+   been renamed to `findByFullName`.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MPL-v2.0

Getters are expected to return a result or fail with an exception.
Find methods are allowed to return null when no results were found.