### PR TITLE
[Core] Move Administrator to it’s own namespace

### DIFF
--- a/src/Bundle/CoreBundle/Cli/Command/RegisterAdministratorCommand.php
+++ b/src/Bundle/CoreBundle/Cli/Command/RegisterAdministratorCommand.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace ParkManager\Bundle\CoreBundle\Cli\Command;
 
 use League\Tactician\CommandBus;
-use ParkManager\Component\Core\Model\Command\RegisterAdministrator;
+use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
 use ParkManager\Component\User\Model\UserId;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Bundle/CoreBundle/Model/DoctrineOrmAdministratorRepository.php
+++ b/src/Bundle/CoreBundle/Model/DoctrineOrmAdministratorRepository.php
@@ -16,8 +16,8 @@ namespace ParkManager\Bundle\CoreBundle\Model;
 
 use Doctrine\ORM\EntityManagerInterface;
 use ParkManager\Bundle\UserBundle\Model\DoctrineOrmUserCollection;
-use ParkManager\Component\Core\Model\Administrator;
-use ParkManager\Component\Core\Model\AdministratorRepository;
+use ParkManager\Component\Core\Model\Administrator\Administrator;
+use ParkManager\Component\Core\Model\Administrator\AdministratorRepository;
 use ParkManager\Component\Model\Event\EventEmitter;
 
 /**

--- a/src/Bundle/CoreBundle/ParkManagerCoreBundle.php
+++ b/src/Bundle/CoreBundle/ParkManagerCoreBundle.php
@@ -48,7 +48,7 @@ class ParkManagerCoreBundle extends Bundle
         $container->addCompilerPass(
             DoctrineOrmMappingsPass::createXmlMappingDriver([
                 realpath($dirname.'/Resources/Mapping/Security') => 'ParkManager\\Component\\Security',
-                realpath(__DIR__.'/Resources/config/Doctrine/Core') => 'ParkManager\\Component\\Core\\Model',
+                realpath(__DIR__.'/Resources/config/Doctrine/Administrator') => 'ParkManager\\Component\\Core\\Model\\Administrator',
             ])
         );
     }

--- a/src/Bundle/CoreBundle/Resources/config/Doctrine/Administrator/Administrator.orm.xml
+++ b/src/Bundle/CoreBundle/Resources/config/Doctrine/Administrator/Administrator.orm.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="ParkManager\Component\Core\Model\Administrator" table="administrator">
+    <entity name="ParkManager\Component\Core\Model\Administrator\Administrator" table="administrator">
         <field name="firstName" column="first_name" type="string" />
         <field name="lastName" column="last_name" type="string" />
     </entity>

--- a/src/Bundle/CoreBundle/Resources/config/services/administrator.php
+++ b/src/Bundle/CoreBundle/Resources/config/services/administrator.php
@@ -35,7 +35,7 @@ use ParkManager\Bundle\UserBundle\ReadModel\DbalUserFinder;
 use ParkManager\Bundle\UserBundle\Security\DbalUserProvider;
 use ParkManager\Bundle\UserBundle\Security\FormAuthenticator;
 use ParkManager\Bundle\UserBundle\Service\PasswordResetSwiftMailer;
-use ParkManager\Component\Core\Model\Handler\RegisterAdministratorHandler;
+use ParkManager\Component\Core\Model\Administrator\Handler\RegisterAdministratorHandler;
 use ParkManager\Component\Model\Event\EventEmitter;
 use ParkManager\Component\ServiceBus\QueryBus;
 use ParkManager\Component\User\Canonicalizer\SimpleEmailCanonicalizer;

--- a/src/Component/Core/Model/Administrator/Administrator.php
+++ b/src/Component/Core/Model/Administrator/Administrator.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model;
+namespace ParkManager\Component\Core\Model\Administrator;
 
-use ParkManager\Component\Core\Model\Event\AdministratorNameWasChanged;
-use ParkManager\Component\Core\Model\Event\AdministratorWasRegistered;
+use ParkManager\Component\Core\Model\Administrator\Event\AdministratorNameWasChanged;
+use ParkManager\Component\Core\Model\Administrator\Event\AdministratorWasRegistered;
 use ParkManager\Component\User\Model\User;
 use ParkManager\Component\User\Model\UserId;
 

--- a/src/Component/Core/Model/Administrator/AdministratorRepository.php
+++ b/src/Component/Core/Model/Administrator/AdministratorRepository.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model;
+namespace ParkManager\Component\Core\Model\Administrator;
 
 use ParkManager\Component\User\Model\UserCollection;
 use ParkManager\Component\User\Model\UserId;

--- a/src/Component/Core/Model/Administrator/Command/RegisterAdministrator.php
+++ b/src/Component/Core/Model/Administrator/Command/RegisterAdministrator.php
@@ -12,30 +12,47 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model\Event;
+namespace ParkManager\Component\Core\Model\Administrator\Command;
 
-use ParkManager\Component\Model\Event\DomainEvent;
 use ParkManager\Component\User\Model\UserId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  */
-class AdministratorNameWasChanged extends DomainEvent
+final class RegisterAdministrator
 {
     private $id;
+    private $email;
     private $firstName;
     private $lastName;
+    private $password;
 
-    public function __construct(UserId $id, string $firstName, string $lastName)
+    /**
+     * Constructor.
+     *
+     * @param string      $id
+     * @param string      $email
+     * @param string      $firstName
+     * @param string      $lastName
+     * @param null|string $password  Null (no password) or an encoded password string (not plain)
+     */
+    public function __construct(string $id, string $email, string $firstName, string $lastName, ?string $password = null)
     {
-        $this->id = $id;
+        $this->id = UserId::fromString($id);
+        $this->email = $email;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
+        $this->password = $password;
     }
 
     public function id(): UserId
     {
         return $this->id;
+    }
+
+    public function email(): string
+    {
+        return $this->email;
     }
 
     public function firstName(): string
@@ -46,5 +63,10 @@ class AdministratorNameWasChanged extends DomainEvent
     public function lastName(): string
     {
         return $this->lastName;
+    }
+
+    public function password(): ?string
+    {
+        return $this->password;
     }
 }

--- a/src/Component/Core/Model/Administrator/Event/AdministratorNameWasChanged.php
+++ b/src/Component/Core/Model/Administrator/Event/AdministratorNameWasChanged.php
@@ -12,47 +12,30 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model\Command;
+namespace ParkManager\Component\Core\Model\Administrator\Event;
 
+use ParkManager\Component\Model\Event\DomainEvent;
 use ParkManager\Component\User\Model\UserId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  */
-final class RegisterAdministrator
+class AdministratorNameWasChanged extends DomainEvent
 {
     private $id;
-    private $email;
     private $firstName;
     private $lastName;
-    private $password;
 
-    /**
-     * Constructor.
-     *
-     * @param string      $id
-     * @param string      $email
-     * @param string      $firstName
-     * @param string      $lastName
-     * @param null|string $password  Null (no password) or an encoded password string (not plain)
-     */
-    public function __construct(string $id, string $email, string $firstName, string $lastName, ?string $password = null)
+    public function __construct(UserId $id, string $firstName, string $lastName)
     {
-        $this->id = UserId::fromString($id);
-        $this->email = $email;
+        $this->id = $id;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
-        $this->password = $password;
     }
 
     public function id(): UserId
     {
         return $this->id;
-    }
-
-    public function email(): string
-    {
-        return $this->email;
     }
 
     public function firstName(): string
@@ -63,10 +46,5 @@ final class RegisterAdministrator
     public function lastName(): string
     {
         return $this->lastName;
-    }
-
-    public function password(): ?string
-    {
-        return $this->password;
     }
 }

--- a/src/Component/Core/Model/Administrator/Event/AdministratorWasRegistered.php
+++ b/src/Component/Core/Model/Administrator/Event/AdministratorWasRegistered.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model\Event;
+namespace ParkManager\Component\Core\Model\Administrator\Event;
 
 use ParkManager\Component\Model\Event\DomainEvent;
 use ParkManager\Component\User\Model\UserId;

--- a/src/Component/Core/Model/Administrator/Exception/AdministratorEmailAddressAlreadyInUse.php
+++ b/src/Component/Core/Model/Administrator/Exception/AdministratorEmailAddressAlreadyInUse.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Exception;
+namespace ParkManager\Component\Core\Model\Administrator\Exception;
 
 final class AdministratorEmailAddressAlreadyInUse extends \InvalidArgumentException
 {

--- a/src/Component/Core/Model/Administrator/Handler/RegisterAdministratorHandler.php
+++ b/src/Component/Core/Model/Administrator/Handler/RegisterAdministratorHandler.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Model\Handler;
+namespace ParkManager\Component\Core\Model\Administrator\Handler;
 
-use ParkManager\Component\Core\Exception\AdministratorEmailAddressAlreadyInUse;
-use ParkManager\Component\Core\Model\Administrator;
-use ParkManager\Component\Core\Model\Command\RegisterAdministrator;
+use ParkManager\Component\Core\Model\Administrator\Administrator;
+use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
+use ParkManager\Component\Core\Model\Administrator\Exception\AdministratorEmailAddressAlreadyInUse;
 use ParkManager\Component\User\Canonicalizer\Canonicalizer;
 use ParkManager\Component\User\Canonicalizer\SimpleEmailCanonicalizer;
 use ParkManager\Component\User\Model\UserCollection;

--- a/src/Component/Core/Tests/Model/Administrator/Command/RegisterAdministratorTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Command/RegisterAdministratorTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Tests\Model\Command;
+namespace ParkManager\Component\Core\Tests\Model\Administrator\Command;
 
-use ParkManager\Component\Core\Model\Command\RegisterAdministrator;
+use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
 use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 

--- a/src/Component/Core/Tests/Model/Administrator/Event/AdministratorNameWasChangedTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Event/AdministratorNameWasChangedTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Tests\Model\Event;
+namespace ParkManager\Component\Core\Tests\Model\Administrator\Event;
 
-use ParkManager\Component\Core\Model\Event\AdministratorNameWasChanged;
+use ParkManager\Component\Core\Model\Administrator\Event\AdministratorNameWasChanged;
 use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 

--- a/src/Component/Core/Tests/Model/Administrator/Event/AdministratorWasRegisteredTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Event/AdministratorWasRegisteredTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Tests\Model\Event;
+namespace ParkManager\Component\Core\Tests\Model\Administrator\Event;
 
-use ParkManager\Component\Core\Model\Event\AdministratorWasRegistered;
+use ParkManager\Component\Core\Model\Administrator\Event\AdministratorWasRegistered;
 use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 

--- a/src/Component/Core/Tests/Model/Administrator/Handler/RegisterUserHandlerTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Handler/RegisterUserHandlerTest.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParkManager\Component\Core\Tests\Model\Handler;
+namespace ParkManager\Component\Core\Tests\Model\Administrator\Handler;
 
-use ParkManager\Component\Core\Exception\AdministratorEmailAddressAlreadyInUse;
-use ParkManager\Component\Core\Model\Administrator;
-use ParkManager\Component\Core\Model\Command\RegisterAdministrator;
-use ParkManager\Component\Core\Model\Handler\RegisterAdministratorHandler;
+use ParkManager\Component\Core\Model\Administrator\Administrator;
+use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
+use ParkManager\Component\Core\Model\Administrator\Exception\AdministratorEmailAddressAlreadyInUse;
+use ParkManager\Component\Core\Model\Administrator\Handler\RegisterAdministratorHandler;
 use ParkManager\Component\User\Model\User;
 use ParkManager\Component\User\Model\UserCollection;
 use ParkManager\Component\User\Model\UserId;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MPL-v2.0

The Core Component is about more then only the Administrator User, to integrate more functionality in the Core component this change makes a better organization.
