### PR TITLE
[Model] Add a few interfaces for paginating

### DIFF
--- a/src/Component/Model/Result/KeysetPageResult.php
+++ b/src/Component/Model/Result/KeysetPageResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Component\Model\Result;
+
+/**
+ * A KeysetPageResult is returned by KeysetPaginable::getPage()
+ * to provide information about the current keyset position (page).
+ *
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+interface KeysetPageResult
+{
+    /**
+     * Returns the ElementIdentifier for this current page.
+     *
+     * This value should be provided when paginating,
+     * helping the Finder to determine the higher items.
+     *
+     * @return mixed either a string or integer
+     */
+    public function lastElementIdentifier();
+
+    /**
+     * Returns whether there are other items from beyond the give keyset.
+     *
+     * @return bool
+     */
+    public function hasNextPage(): bool;
+
+    /**
+     * Returns the items for this current page.
+     *
+     * @return iterable
+     */
+    public function getItems(): iterable;
+}

--- a/src/Component/Model/Result/KeysetPaginable.php
+++ b/src/Component/Model/Result/KeysetPaginable.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Component\Model\Result;
+
+/**
+ * The KeysetPaginable is implemented by a provider to limit
+ * the amount of records returned and providing information
+ * on how to get to the next page (using an ElementIdentifier).
+ *
+ * Note: Unlike offset paging this technique only allows a prev/next
+ * paging but no total or fast forward to a specific page.
+ *
+ * Because of how records are searched the sorting is required,
+ * and cannot be ignored.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ *
+ * @see http://use-the-index-luke.com/no-offset
+ */
+interface KeysetPaginable
+{
+    public const SORT_ASCENDING = 'asc';
+    public const SORT_DESCENDING = 'desc';
+
+    /**
+     * @return array a hash that associates a field (any string) to a sort
+     *               direction. The order of fields inside the array matters
+     */
+    public function sortSpecification(): array;
+
+    /**
+     * @param mixed      $keyset
+     * @param array|null $sorting
+     *
+     * @return KeysetPageResult
+     */
+    public function getPage($keyset, array $sorting = null): KeysetPageResult;
+}

--- a/src/Component/Model/Result/PaginableResult.php
+++ b/src/Component/Model/Result/PaginableResult.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Component\Model\Result;
+
+/**
+ * The PaginableResult is implemented by a provider to limit
+ * the amount of records returned and providing information
+ * about the total count of items.
+ *
+ * For performance reasons this should only be used for results when
+ * offset paginating doesn't have a negative impact or uses an index.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+interface PaginableResult
+{
+    public function totalCountOfItems(): int;
+
+    /**
+     * Returns a portion of the total result.
+     */
+    public function slice(int $offset, int $limit): iterable;
+}

--- a/src/Component/Model/Result/SortablePaginableResult.php
+++ b/src/Component/Model/Result/SortablePaginableResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Component\Model\Result;
+
+/**
+ * The SortablePaginableResult is implemented by a provider to limit
+ * the amount of records returned, providing information about the
+ * total count of items, and which sorting is accepted.
+ *
+ * For performance reasons this should only be used for results when
+ * offset paginating doesn't have a negative impact or uses an index.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+interface SortablePaginableResult extends PaginableResult
+{
+    public const SORT_ASCENDING = 'asc';
+    public const SORT_DESCENDING = 'desc';
+
+    /**
+     * @return array a hash that associates a field (any string) to a sort
+     *               direction. The order of fields inside the array matters
+     */
+    public function sortSpecification(): array;
+
+    /**
+     * Returns a portion of the total result.
+     *
+     * @param int   $offset
+     * @param int   $limit
+     * @param array $sorting a hash of fields and there sorting eg. [id => asc]
+     *
+     * @return iterable
+     */
+    public function slice(int $offset, int $limit, ?array $sorting = null): iterable;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MPL-v2.0

These interfaces can be implemented by Result objects and returned by the QueryBus, using these interfaces makes it possible to have a generic Pager in the UI layer.

**Note:** The actual UI Pager is planned for a later sprint. A reusable implementation of the Result objects is also planned for later as there must to be a commonality within usage.