### PR TITLE
[DoctrineBridge] Introduce DomainIdType

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1800,16 +1800,16 @@
         },
         {
             "name": "rollerworks/app-sectioning",
-            "version": "v0.6.0",
+            "version": "v0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rollerworks/app-sectioning.git",
-                "reference": "d6eaa8d0d2a2b699beb2cff943f716e3882dc284"
+                "reference": "9b269c8c8eadca49c3b038e0a90ac88e7a41b049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rollerworks/app-sectioning/zipball/d6eaa8d0d2a2b699beb2cff943f716e3882dc284",
-                "reference": "d6eaa8d0d2a2b699beb2cff943f716e3882dc284",
+                "url": "https://api.github.com/repos/rollerworks/app-sectioning/zipball/9b269c8c8eadca49c3b038e0a90ac88e7a41b049",
+                "reference": "9b269c8c8eadca49c3b038e0a90ac88e7a41b049",
                 "shasum": ""
             },
             "require": {
@@ -1829,7 +1829,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.5-dev"
+                    "dev-master": "0.6-dev"
                 }
             },
             "autoload": {
@@ -1851,7 +1851,7 @@
                 }
             ],
             "description": "Configuration helper for separating your Symfony application into multiple sections",
-            "time": "2018-03-07T19:02:48+00:00"
+            "time": "2018-03-18T14:46:51+00:00"
         },
         {
             "name": "rollerworks/route-autowiring-bundle",

--- a/src/Bridge/Doctrine/Type/DomainIdType.php
+++ b/src/Bridge/Doctrine/Type/DomainIdType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Bridge\Doctrine\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\GuidType;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+abstract class DomainIdType extends GuidType
+{
+    public const NAME = 'park_manager_domain_id';
+    public const OBJECT_CLASS = null;
+
+    final public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    final public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
+
+    final public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (null === $value || is_string($value)) {
+            return $value;
+        }
+
+        return $value->toString();
+    }
+
+    final public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (null === $value) {
+            return $value;
+        }
+
+        $class = static::OBJECT_CLASS;
+
+        return $class::fromString($value);
+    }
+}

--- a/src/Bundle/CoreBundle/DependencyInjection/DependencyExtension.php
+++ b/src/Bundle/CoreBundle/DependencyInjection/DependencyExtension.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace ParkManager\Bundle\CoreBundle\DependencyInjection;
 
 use ParkManager\Bridge\Doctrine\Type\ArrayCollectionType;
+use ParkManager\Bundle\CoreBundle\Doctrine\Type\AdministratorIdType;
 use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -61,7 +62,10 @@ final class DependencyExtension extends Extension implements PrependExtensionInt
     {
         $container->prependExtensionConfig('doctrine', [
             'dbal' => [
-                'types' => ['array_collection' => ['class' => ArrayCollectionType::class, 'commented' => true]],
+                'types' => [
+                    'array_collection' => ['class' => ArrayCollectionType::class, 'commented' => true],
+                    AdministratorIdType::NAME => ['class' => AdministratorIdType::class, 'commented' => true],
+                ],
             ],
         ]);
     }

--- a/src/Bundle/CoreBundle/Doctrine/Type/AdministratorIdType.php
+++ b/src/Bundle/CoreBundle/Doctrine/Type/AdministratorIdType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Bundle\CoreBundle\Doctrine\Type;
+
+use ParkManager\Bridge\Doctrine\Type\DomainIdType;
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+final class AdministratorIdType extends DomainIdType
+{
+    public const NAME = 'park_manager_administrator_id';
+    public const OBJECT_CLASS = AdministratorId::class;
+}

--- a/src/Bundle/CoreBundle/Resources/config/Doctrine/Administrator/Administrator.orm.xml
+++ b/src/Bundle/CoreBundle/Resources/config/Doctrine/Administrator/Administrator.orm.xml
@@ -5,6 +5,9 @@
         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="ParkManager\Component\Core\Model\Administrator\Administrator" table="administrator">
+        <id name="id" type="park_manager_administrator_id">
+            <generator strategy="NONE" />
+        </id>
         <field name="firstName" column="first_name" type="string" />
         <field name="lastName" column="last_name" type="string" />
     </entity>

--- a/src/Bundle/UserBundle/Model/DoctrineOrmUserCollection.php
+++ b/src/Bundle/UserBundle/Model/DoctrineOrmUserCollection.php
@@ -42,7 +42,7 @@ class DoctrineOrmUserCollection extends EntityRepository implements UserCollecti
     public function get(UserId $id): User
     {
         /** @var User $user */
-        if (null === $user = $this->find($id->toString())) {
+        if (null === $user = $this->find($id)) {
             throw UserNotFound::withUserId($id);
         }
 

--- a/src/Bundle/UserBundle/Resources/config/Doctrine/User.orm.xml
+++ b/src/Bundle/UserBundle/Resources/config/Doctrine/User.orm.xml
@@ -5,9 +5,6 @@
         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="ParkManager\Component\User\Model\User" table="users">
-        <id name="id" type="guid">
-            <generator strategy="NONE" />
-        </id>
         <field name="email" column="email" type="text" />
         <field name="canonicalEmail" column="canonical_email" type="text" />
         <field name="password" column="auth_password" type="text" nullable="true" />

--- a/src/Component/Core/Model/Administrator/Administrator.php
+++ b/src/Component/Core/Model/Administrator/Administrator.php
@@ -17,12 +17,13 @@ namespace ParkManager\Component\Core\Model\Administrator;
 use ParkManager\Component\Core\Model\Administrator\Event\AdministratorNameWasChanged;
 use ParkManager\Component\Core\Model\Administrator\Event\AdministratorWasRegistered;
 use ParkManager\Component\User\Model\User;
-use ParkManager\Component\User\Model\UserId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  *
  * @final
+ *
+ * @method id(): AdministratorId
  */
 class Administrator extends User
 {
@@ -37,7 +38,7 @@ class Administrator extends User
     private $lastName;
 
     public static function registerWith(
-        UserId $id,
+        AdministratorId $id,
         string $email,
         string $canonicalEmail,
         string $firstName,
@@ -58,7 +59,7 @@ class Administrator extends User
     {
         $this->firstName = $firstName;
         $this->lastName = $lastName;
-        $this->recordThat(new AdministratorNameWasChanged($this->id(), $firstName, $lastName));
+        $this->recordThat(new AdministratorNameWasChanged($this->id, $firstName, $lastName));
     }
 
     public function firstName(): string

--- a/src/Component/Core/Model/Administrator/AdministratorId.php
+++ b/src/Component/Core/Model/Administrator/AdministratorId.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Component\Core\Model\Administrator;
+
+use ParkManager\Component\User\Model\UserId;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+final class AdministratorId extends UserId
+{
+}

--- a/src/Component/Core/Model/Administrator/Command/RegisterAdministrator.php
+++ b/src/Component/Core/Model/Administrator/Command/RegisterAdministrator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace ParkManager\Component\Core\Model\Administrator\Command;
 
-use ParkManager\Component\User\Model\UserId;
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
@@ -38,14 +38,14 @@ final class RegisterAdministrator
      */
     public function __construct(string $id, string $email, string $firstName, string $lastName, ?string $password = null)
     {
-        $this->id = UserId::fromString($id);
+        $this->id = AdministratorId::fromString($id);
         $this->email = $email;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
         $this->password = $password;
     }
 
-    public function id(): UserId
+    public function id(): AdministratorId
     {
         return $this->id;
     }

--- a/src/Component/Core/Model/Administrator/Event/AdministratorWasRegistered.php
+++ b/src/Component/Core/Model/Administrator/Event/AdministratorWasRegistered.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace ParkManager\Component\Core\Model\Administrator\Event;
 
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 use ParkManager\Component\Model\Event\DomainEvent;
-use ParkManager\Component\User\Model\UserId;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
@@ -27,7 +27,7 @@ final class AdministratorWasRegistered extends DomainEvent
     private $firstName;
     private $lastName;
 
-    public function __construct(UserId $id, string $email, string $firstName, string $lastName)
+    public function __construct(AdministratorId $id, string $email, string $firstName, string $lastName)
     {
         $this->id = $id;
         $this->email = $email;
@@ -35,7 +35,7 @@ final class AdministratorWasRegistered extends DomainEvent
         $this->lastName = $lastName;
     }
 
-    public function id(): UserId
+    public function id(): AdministratorId
     {
         return $this->id;
     }

--- a/src/Component/Core/Tests/Model/Administrator/Command/RegisterAdministratorTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Command/RegisterAdministratorTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace ParkManager\Component\Core\Tests\Model\Administrator\Command;
 
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
-use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +30,7 @@ final class RegisterAdministratorTest extends TestCase
     {
         $command = new RegisterAdministrator(self::USER_ID, 'John@example.com', 'First', 'Last', 'empty');
 
-        self::assertEquals(UserId::fromString(self::USER_ID), $command->id());
+        self::assertEquals(AdministratorId::fromString(self::USER_ID), $command->id());
         self::assertEquals('John@example.com', $command->email());
         self::assertEquals('First', $command->firstName());
         self::assertEquals('Last', $command->lastName());
@@ -42,7 +42,7 @@ final class RegisterAdministratorTest extends TestCase
     {
         $command = new RegisterAdministrator(self::USER_ID, 'John@example.com', 'First', 'Last');
 
-        self::assertEquals(UserId::fromString(self::USER_ID), $command->id());
+        self::assertEquals(AdministratorId::fromString(self::USER_ID), $command->id());
         self::assertEquals('John@example.com', $command->email());
         self::assertEquals('First', $command->firstName());
         self::assertEquals('Last', $command->lastName());

--- a/src/Component/Core/Tests/Model/Administrator/Event/AdministratorNameWasChangedTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Event/AdministratorNameWasChangedTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace ParkManager\Component\Core\Tests\Model\Administrator\Event;
 
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 use ParkManager\Component\Core\Model\Administrator\Event\AdministratorNameWasChanged;
-use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,9 +28,9 @@ final class AdministratorNameWasChangedTest extends TestCase
     /** @test */
     public function its_constructable()
     {
-        $command = new AdministratorNameWasChanged($id = UserId::fromString(self::USER_ID), 'First', 'Named');
+        $command = new AdministratorNameWasChanged($id = AdministratorId::fromString(self::USER_ID), 'First', 'Named');
 
-        self::assertEquals(UserId::fromString(self::USER_ID), $command->id());
+        self::assertEquals(AdministratorId::fromString(self::USER_ID), $command->id());
         self::assertTrue($id->equals($command->id()));
         self::assertEquals('Named', $command->lastName());
         self::assertEquals('First', $command->firstName());

--- a/src/Component/Core/Tests/Model/Administrator/Event/AdministratorWasRegisteredTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Event/AdministratorWasRegisteredTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 
 namespace ParkManager\Component\Core\Tests\Model\Administrator\Event;
 
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 use ParkManager\Component\Core\Model\Administrator\Event\AdministratorWasRegistered;
-use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,9 +28,9 @@ final class AdministratorWasRegisteredTest extends TestCase
     /** @test */
     public function its_constructable()
     {
-        $command = new AdministratorWasRegistered($id = UserId::fromString(self::USER_ID), 'Jane@example.com', 'First', 'Named');
+        $command = new AdministratorWasRegistered($id = AdministratorId::fromString(self::USER_ID), 'Jane@example.com', 'First', 'Named');
 
-        self::assertEquals(UserId::fromString(self::USER_ID), $command->id());
+        self::assertEquals(AdministratorId::fromString(self::USER_ID), $command->id());
         self::assertTrue($id->equals($command->id()));
         self::assertEquals('Jane@example.com', $command->email());
         self::assertEquals('Named', $command->lastName());

--- a/src/Component/Core/Tests/Model/Administrator/Handler/RegisterUserHandlerTest.php
+++ b/src/Component/Core/Tests/Model/Administrator/Handler/RegisterUserHandlerTest.php
@@ -15,12 +15,12 @@ declare(strict_types=1);
 namespace ParkManager\Component\Core\Tests\Model\Administrator\Handler;
 
 use ParkManager\Component\Core\Model\Administrator\Administrator;
+use ParkManager\Component\Core\Model\Administrator\AdministratorId;
 use ParkManager\Component\Core\Model\Administrator\Command\RegisterAdministrator;
 use ParkManager\Component\Core\Model\Administrator\Exception\AdministratorEmailAddressAlreadyInUse;
 use ParkManager\Component\Core\Model\Administrator\Handler\RegisterAdministratorHandler;
 use ParkManager\Component\User\Model\User;
 use ParkManager\Component\User\Model\UserCollection;
-use ParkManager\Component\User\Model\UserId;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -60,9 +60,9 @@ final class RegisterUserHandlerTest extends TestCase
         $handler(new RegisterAdministrator(self::ID_NEW, 'John@example.com', 'My', 'name', null));
     }
 
-    private function existingId(): UserId
+    private function existingId(): AdministratorId
     {
-        return UserId::fromString(self::ID_EXISTING);
+        return AdministratorId::fromString(self::ID_EXISTING);
     }
 
     private function expectUserSaved(RegisterAdministrator $command): UserCollection

--- a/src/Component/User/Model/User.php
+++ b/src/Component/User/Model/User.php
@@ -37,14 +37,9 @@ abstract class User extends EventsRecordingEntity
     public const DEFAULT_ROLE = 'ROLE_USER';
 
     /**
-     * @var string
-     */
-    protected $id;
-
-    /**
      * @var UserId
      */
-    protected $idObj;
+    protected $id;
 
     /**
      * @var string
@@ -83,25 +78,15 @@ abstract class User extends EventsRecordingEntity
 
     protected function __construct(UserId $id, string $email, string $canonicalEmail)
     {
-        $this->id = $id->toString();
-        $this->idObj = $id;
+        $this->id = $id;
         $this->email = $email;
         $this->canonicalEmail = $canonicalEmail;
         $this->roles = new ArrayCollection(static::getDefaultRoles());
     }
 
-    /**
-     * Returns the id of the user.
-     *
-     * @return UserId
-     */
     public function id(): UserId
     {
-        if (null === $this->idObj) {
-            $this->idObj = UserId::fromString($this->id);
-        }
-
-        return $this->idObj;
+        return $this->id;
     }
 
     /**

--- a/src/Component/User/Tests/Model/UserTest.php
+++ b/src/Component/User/Tests/Model/UserTest.php
@@ -49,12 +49,6 @@ final class UserTest extends TestCase
     }
 
     /** @test */
-    public function its_id_is_correct_after_hydration()
-    {
-        self::assertHydratedObjectValueEquals(UserImplementation::class, self::ID1, UserId::fromString(self::ID1));
-    }
-
-    /** @test */
     public function it_can_changes_email()
     {
         $user = $this->createUser();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MPL-v2.0

The abstract `DomainIdType` allows to easily register custom UUID ValueObject DBAL types, instead of having to keep this logic in the Entity itself.

**Note:** Each type needs to be registered (as normal). In a follow-up pr I plan to add an automation for this registering (convention based and with a configurator).