### PR TITLE
[Core] Introduce and apply a new Module DI system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         },
         "symfony": {
             "id": "01BF6RBYGY5V4S3FDMBNKXVVNS",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -13,7 +13,7 @@ return [
     \ParkManager\Core\ParkManagerCore::class => ['all' => true],
     ParkManager\Bundle\UserBundle\ParkManagerUserBundle::class => ['all' => true],
     ParkManager\Bundle\TestBundle\ParkManagerTestBundle::class => ['test' => true],
-    ParkManager\Module\Webhosting\ParkManagerWebhostingBundle::class => ['all' => true],
+    ParkManager\Module\Webhosting\ParkManagerWebhostingModule::class => ['all' => true],
     Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],

--- a/src/Bridge/Doctrine/composer.json
+++ b/src/Bridge/Doctrine/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Bridge/ServiceBus/composer.json
+++ b/src/Bridge/ServiceBus/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/service-bus": "^0.2",
+        "park-manager/service-bus": "^0.3",
         "symfony/dependency-injection": "^4.0",
         "league/tactician-container": "^2.0.0"
     },

--- a/src/Bundle/ServiceBusBundle/composer.json
+++ b/src/Bundle/ServiceBusBundle/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/service-bus-bridge": "^0.2",
+        "park-manager/service-bus-bridge": "^0.3",
         "symfony/framework-bundle": "^4.0"
     },
     "config": {

--- a/src/Bundle/ServiceBusPolicyGuardBundle/composer.json
+++ b/src/Bundle/ServiceBusPolicyGuardBundle/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/service-bus-bundle": "^0.2",
+        "park-manager/service-bus-bundle": "^0.3",
         "symfony/expression-language": "^4.0",
         "symfony/framework-bundle": "^4.0",
         "symfony/security-bundle": "^4.0"

--- a/src/Bundle/UserBundle/composer.json
+++ b/src/Bundle/UserBundle/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "php": "^7.2",
         "hostnet/form-handler-bundle": "^1.4.1",
-        "park-manager/doctrine-bridge": "^0.2",
-        "park-manager/user": "^0.2",
-        "park-manager/service-bus-bundle": "^0.2",
+        "park-manager/doctrine-bridge": "^0.3",
+        "park-manager/user": "^0.3",
+        "park-manager/service-bus-bundle": "^0.3",
         "sylius/mailer": "^1.0",
         "sylius/mailer-bundle": "^1.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Component/Model/composer.json
+++ b/src/Component/Model/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Component/Security/composer.json
+++ b/src/Component/Security/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Component/User/composer.json
+++ b/src/Component/User/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/model": "^0.2",
-        "park-manager/security": "^0.2",
+        "park-manager/model": "^0.3",
+        "park-manager/security": "^0.3",
         "symfony/security-core": "^3.4 || ^4.0"
     },
     "config": {
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Core/Infrastructure/DependencyInjection/Module/AbstractParkManagerModule.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/AbstractParkManagerModule.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+abstract class AbstractParkManagerModule extends Bundle implements ParkManagerModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainerExtension()
+    {
+        if (null === $this->extension) {
+            $extension = $this->createContainerExtension();
+
+            if (null !== $extension) {
+                if (!$extension instanceof ExtensionInterface) {
+                    throw new \LogicException(
+                        sprintf(
+                            'Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.',
+                            get_class($extension)
+                        )
+                    );
+                }
+
+                // check naming convention
+                // Park-Manager vendor Modules don't have to follow the alias convention
+                $basename = preg_replace('/Module$/', '', $this->getName());
+                $expectedAlias = Container::underscore($basename);
+
+                if ($expectedAlias !== $extension->getAlias()) {
+                    throw new \LogicException(
+                        sprintf(
+                            'Users will expect the alias of the default extension of a module to be the underscored version of the module name ("%s"). '.
+                            'You can override "AbstractParkManagerModule::getContainerExtension()" if you want to use "%s" or another alias.',
+                            $expectedAlias,
+                            $extension->getAlias()
+                        )
+                    );
+                }
+
+                $this->extension = $extension;
+            } else {
+                $this->extension = false;
+            }
+        }
+
+        if ($this->extension) {
+            return $this->extension;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        if (0 !== count($doctrineMapping = $this->getDoctrineMappings())) {
+            $container->addCompilerPass(
+                DoctrineOrmMappingsPass::createXmlMappingDriver($doctrineMapping, $this->getDoctrineEmNames())
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensionClass(): string
+    {
+        return $this->getNamespace().'\\Infrastructure\\DependencyInjection\\DependencyExtension';
+    }
+
+    protected function getDoctrineEmNames(): array
+    {
+        return [];
+    }
+
+    protected function getDoctrineMappings(): array
+    {
+        $path = $this->getPath().'/Infrastructure/Doctrine/';
+        $namespace = $this->getNamespace();
+        $mappings = [];
+
+        if (file_exists($path)) {
+            foreach (new \DirectoryIterator($path) as $node) {
+                if ($node->isDot()) {
+                    continue;
+                }
+
+                $basename = $node->getBasename();
+                $directory = $path.$basename.'/Mapping';
+
+                if (file_exists($directory)) {
+                    $mappings[$directory] = $namespace.'\\Domain\\'.$basename;
+                }
+            }
+        }
+
+        return $mappings;
+    }
+}

--- a/src/Core/Infrastructure/DependencyInjection/Module/ParkManagerModule.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/ParkManagerModule.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+interface ParkManagerModule extends BundleInterface
+{
+}

--- a/src/Core/Infrastructure/DependencyInjection/Module/ParkManagerModuleDependencyExtension.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/ParkManagerModuleDependencyExtension.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module;
+
+use ParkManager\Core\Infrastructure\DependencyInjection\Module\Traits\DoctrineDbalTypesConfiguratorTrait;
+use ParkManager\Core\Infrastructure\DependencyInjection\Module\Traits\ServiceLoaderTrait;
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+abstract class ParkManagerModuleDependencyExtension extends Extension implements PrependExtensionInterface
+{
+    use DoctrineDbalTypesConfiguratorTrait;
+    use ServiceLoaderTrait;
+
+    protected $moduleDir;
+
+    /**
+     * Name of this Module (with vendor namespace).
+     *
+     * @return string eg. AcmeWebhosting
+     */
+    abstract public function getModuleName(): string;
+
+    /**
+     * Configures a number of common operations.
+     * Use loadModule() to load additional configurations.
+     *
+     * @param array            $configs
+     * @param ContainerBuilder $container
+     *
+     * @internal
+     */
+    final public function load(array $configs, ContainerBuilder $container): void
+    {
+        $this->initModuleDirectory();
+
+        $routeImporter = new RouteImporter($container);
+        $routeImporter->addObjectResource($this);
+        $this->registerRoutes($routeImporter, realpath($this->moduleDir.'/Infrastructure/Resources/config') ?: null);
+
+        $loader = $this->getServiceLoader($container, $this->moduleDir.'/Infrastructure/Resources/config/services');
+        $this->loadModule($configs, $container, $loader);
+    }
+
+    /**
+     * Configures the translator paths, templates paths, and DomainId
+     * DBAL types. Use prependExtra() to prepend extension configurations.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @internal
+     */
+    final public function prepend(ContainerBuilder $container): void
+    {
+        $this->initModuleDirectory();
+        $resourcesDirectory = $this->moduleDir.'/Infrastructure/Resources';
+
+        if (is_dir($resourcesDirectory.'/translations')) {
+            $container->prependExtensionConfig('framework', [
+                'translator' => [
+                    'paths' => [$resourcesDirectory.'/translations'],
+                ],
+            ]);
+        }
+
+        if (is_dir($resourcesDirectory.'/templates')) {
+            $container->prependExtensionConfig('twig', [
+                'paths' => [$resourcesDirectory.'/templates' => $this->getModuleName()],
+            ]);
+        }
+
+        $this->registerDoctrineDbalTypes($container, $this->moduleDir);
+        $this->prependExtra($container);
+    }
+
+    /**
+     * Loads a specific configuration.
+     *
+     * @param array            $configs   The configs (unprocessed)
+     * @param ContainerBuilder $container
+     * @param LoaderInterface  $loader    Service definitions loader for all supported types
+     *                                    including Glob, Directory, Closure and ini
+     */
+    protected function loadModule(array $configs, ContainerBuilder $container, LoaderInterface $loader): void
+    {
+    }
+
+    /**
+     * Allow an extension to prepend the extension configurations.
+     *
+     * prepend() is final, use this method instead.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function prependExtra(ContainerBuilder $container): void
+    {
+    }
+
+    /**
+     * Registers the routes using the RouteImporter importer.
+     *
+     * Use the following slots for sections:
+     *
+     * * 'park_manager.client_section.root': Client section root
+     * * 'park_manager.admin_section.root': Admin section root
+     * * 'park_manager.api_section.root': API (both client and admin)
+     *
+     * Or use 'park_manager.root' to import at the root (/)
+     * of the routing scheme (only for error pages and utils).
+     *
+     * Example:
+     *
+     *   $routeImporter->import($configDir.'/routing/client.php', 'park_manager.client_section.root');
+     *   $routeImporter->import($configDir.'/routing/admin.php', 'park_manager.admin_section.root');
+     *
+     * @param RouteImporter $routeImporter
+     * @param string        $configDir     Full path of Resources/config directory
+     *                                     (null when missing)
+     */
+    protected function registerRoutes(RouteImporter $routeImporter, ?string $configDir): void
+    {
+    }
+
+    final protected function initModuleDirectory(): void
+    {
+        if (null === $this->moduleDir) {
+            $this->moduleDir = \dirname((new \ReflectionObject($this))->getFileName(), 3);
+        }
+    }
+}

--- a/src/Core/Infrastructure/DependencyInjection/Module/Traits/DoctrineDbalTypesConfiguratorTrait.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/Traits/DoctrineDbalTypesConfiguratorTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module\Traits;
+
+use Doctrine\DBAL\Types\Type as DbalType;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Helps with automatically registering Doctrine DBAL types.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+trait DoctrineDbalTypesConfiguratorTrait
+{
+    /**
+     * Registers the Doctrine DBAL Types (located in Module/Infrastructure/Doctrine).
+     *
+     * Overwrite this method to skip/change registering.
+     * All types are assumed to be commented.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function registerDoctrineDbalTypes(ContainerBuilder $container, string $moduleDirectory): void
+    {
+        if (!file_exists($moduleDirectory.'/Infrastructure/Doctrine')) {
+            return;
+        }
+
+        $finder = new Finder();
+        $finder->in($moduleDirectory.'/Infrastructure/Doctrine');
+        $finder->name('*.php');
+        $finder->files();
+
+        $namespace = preg_replace('/\\\DependencyInjection\\\DependencyExtension$/', '', static::class).'\\Doctrine\\';
+        $types = [];
+
+        foreach ($finder as $node) {
+            $className = $namespace.str_replace('/', '\\', mb_substr($node->getRelativePathname(), 0, -4));
+
+            if (class_exists($className) && is_subclass_of($className, DbalType::class)) {
+                /** @var DbalType $type */
+                $type = (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+                $types[$type->getName()] = ['class' => $className, 'commented' => true];
+            }
+        }
+
+        $container->prependExtensionConfig('doctrine', [
+            'dbal' => [
+                'types' => $types,
+            ],
+        ]);
+    }
+}

--- a/src/Core/Infrastructure/DependencyInjection/Module/Traits/RegisterSectionRoutesTrait.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/Traits/RegisterSectionRoutesTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module\Traits;
+
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+trait RegisterSectionRoutesTrait
+{
+    /**
+     * Registers the routes using the RouteImporter importer.
+     *
+     * Routing files are registers when they exists.
+     */
+    final protected function registerRoutes(RouteImporter $routeImporter, ?string $configDir): void
+    {
+        if (file_exists($configDir.'/routing/client.php')) {
+            $routeImporter->import($configDir.'/routing/client.php', 'park_manager.client_section.root');
+        }
+
+        if (file_exists($configDir.'/routing/admin.php')) {
+            $routeImporter->import($configDir.'/routing/admin.php', 'park_manager.admin_section.root');
+        }
+
+        if (file_exists($configDir.'/routing/api.php')) {
+            $routeImporter->import($configDir.'/routing/api.php', 'park_manager.api_section.root');
+        }
+    }
+}

--- a/src/Core/Infrastructure/DependencyInjection/Module/Traits/ServiceLoaderTrait.php
+++ b/src/Core/Infrastructure/DependencyInjection/Module/Traits/ServiceLoaderTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) the Contributors as noted in the AUTHORS file.
+ *
+ * This file is part of the Park-Manager project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace ParkManager\Core\Infrastructure\DependencyInjection\Module\Traits;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\GlobFileLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\{
+    ClosureLoader,
+    DirectoryLoader,
+    IniFileLoader,
+    PhpFileLoader,
+    XmlFileLoader,
+    YamlFileLoader
+};
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerworks.net>
+ */
+trait ServiceLoaderTrait
+{
+    protected function getServiceLoader(ContainerBuilder $container, $servicesPath): DelegatingLoader
+    {
+        $locator = new FileLocator($servicesPath);
+        $resolver = new LoaderResolver([
+            new PhpFileLoader($container, $locator),
+            new XmlFileLoader($container, $locator),
+            new YamlFileLoader($container, $locator),
+            new IniFileLoader($container, $locator),
+            new GlobFileLoader($locator),
+            new DirectoryLoader($container, $locator),
+            new ClosureLoader($container),
+        ]);
+
+        return new DelegatingLoader($resolver);
+    }
+}

--- a/src/Core/Infrastructure/Resources/config/services/core.php
+++ b/src/Core/Infrastructure/Resources/config/services/core.php
@@ -23,6 +23,4 @@ return function (ContainerConfigurator $c) {
     // back to higher layers.
     $di->set('park_manager.service_bus.log_messages', LogMessages::class)
         ->alias(LogMessages::class, 'park_manager.service_bus.log_messages');
-
-    $c->import('services/administrator.php');
 };

--- a/src/Core/ParkManagerCore.php
+++ b/src/Core/ParkManagerCore.php
@@ -14,18 +14,17 @@ declare(strict_types=1);
 
 namespace ParkManager\Core;
 
-use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use ParkManager\Bridge\Doctrine\Type\ArrayCollectionType;
 use ParkManager\Bundle\UserBundle\DependencyInjection\Compiler\UserFormHandlerPass;
 use ParkManager\Core\Infrastructure\DependencyInjection\DependencyExtension;
+use ParkManager\Core\Infrastructure\DependencyInjection\Module\AbstractParkManagerModule;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  */
-class ParkManagerCore extends Bundle
+class ParkManagerCore extends AbstractParkManagerModule
 {
     public function getContainerExtension(): DependencyExtension
     {
@@ -38,20 +37,23 @@ class ParkManagerCore extends Bundle
 
     public function build(ContainerBuilder $container)
     {
-        $dirname = dirname((new \ReflectionClass(ArrayCollectionType::class))->getFileName(), 2);
+        parent::build($container);
 
         $container->addCompilerPass(
             new UserFormHandlerPass('park_manager.form_handler.administrator.handler_registry', 'admin_form.handler'),
             PassConfig::TYPE_BEFORE_REMOVING
         );
-        $container->addCompilerPass(
-            DoctrineOrmMappingsPass::createXmlMappingDriver([
-                realpath($dirname.'/Resources/Mapping/Security') => 'ParkManager\\Component\\Security',
-                realpath(
-                    __DIR__.'/Infrastructure/Doctrine/Administrator/Mapping'
-                ) => 'ParkManager\\Core\\Domain\\Administrator',
-            ])
-        );
+    }
+
+    protected function getDoctrineMappings(): array
+    {
+        $mapping = parent::getDoctrineMappings();
+        $mapping[realpath(
+            \dirname((new \ReflectionClass(ArrayCollectionType::class))->getFileName(), 2).
+            '/Resources/Mapping/Security'
+        )] = 'ParkManager\\Component\\Security';
+
+        return $mapping;
     }
 
     protected function getContainerExtensionClass(): string

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -16,9 +16,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/doctrine-bridge": "^0.2",
-        "park-manager/model": "^0.2",
-        "park-manager/user-bundle": "^0.2",
+        "park-manager/doctrine-bridge": "^0.3",
+        "park-manager/model": "^0.3",
+        "park-manager/user-bundle": "^0.3",
         "rollerworks/app-sectioning-bundle": "^0.4.1@dev",
         "rollerworks/route-autowiring-bundle": "^1.0.1",
         "symfony/console": "^3.4 || ^4.0",
@@ -49,7 +49,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "0.3-dev"
         }
     }
 }

--- a/src/Module/Webhosting/Infrastructure/DependencyInjection/DependencyExtension.php
+++ b/src/Module/Webhosting/Infrastructure/DependencyInjection/DependencyExtension.php
@@ -14,34 +14,29 @@ declare(strict_types=1);
 
 namespace ParkManager\Module\Webhosting\Infrastructure\DependencyInjection;
 
-use Symfony\Component\Config\FileLocator;
+use ParkManager\Core\Infrastructure\DependencyInjection\Module\ParkManagerModuleDependencyExtension;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  */
-final class DependencyExtension extends Extension
+final class DependencyExtension extends ParkManagerModuleDependencyExtension
 {
-    public const EXTENSION_ALIAS = 'webhosting';
+    public const EXTENSION_ALIAS = 'park_manager_webhosting';
 
-    public function load(array $configs, ContainerBuilder $container): void
+    protected function loadModule(array $configs, ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/services'));
-        $loader->load('core.php');
-        $loader->load('account.php');
-        $loader->load('domain_name.php');
-        $loader->load('package.php');
-    }
-
-    public function getConfiguration(array $config, ContainerBuilder $container)
-    {
-        return new Configuration();
+        $loader->load('*.php', 'glob');
     }
 
     public function getAlias(): string
     {
         return self::EXTENSION_ALIAS;
+    }
+
+    public function getModuleName(): string
+    {
+        return 'ParkManagerWebhosting';
     }
 }

--- a/src/Module/Webhosting/Infrastructure/Resources/config/services/package.php
+++ b/src/Module/Webhosting/Infrastructure/Resources/config/services/package.php
@@ -35,7 +35,7 @@ return function (ContainerConfigurator $c) {
         ->bind(EventEmitter::class, ref('park_manager.command_bus.webhosting.domain_event_emitter'))
         ->bind(EntityManagerInterface::class, ref('doctrine.orm.entity_manager'));
 
-    // CapabilitiesFactory alias needs to be public for Doctrine type in ParkManagerWebhostingBundle::boot()
+    // CapabilitiesFactory alias needs to be public for Doctrine type in ParkManagerWebhostingModule::boot()
     $di->set(CapabilitiesRegistry::class)
         ->alias(CapabilitiesFactory::class, CapabilitiesRegistry::class)->public();
 

--- a/src/Module/Webhosting/ParkManagerWebhostingModule.php
+++ b/src/Module/Webhosting/ParkManagerWebhostingModule.php
@@ -14,41 +14,24 @@ declare(strict_types=1);
 
 namespace ParkManager\Module\Webhosting;
 
-use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Doctrine\DBAL\Types\Type;
+use ParkManager\Core\Infrastructure\DependencyInjection\Module\AbstractParkManagerModule;
 use ParkManager\Module\Webhosting\Domain\Package\CapabilitiesFactory;
 use ParkManager\Module\Webhosting\Infrastructure\DependencyInjection\Compiler\{
     CapabilitiesRegistryPass, CommandToCapabilitiesGuardPass
 };
-use ParkManager\Module\Webhosting\Infrastructure\DependencyInjection\DependencyExtension;
 use ParkManager\Module\Webhosting\Infrastructure\Doctrine\Package\WebhostingCapabilitiesType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerworks.net>
  */
-final class ParkManagerWebhostingBundle extends Bundle
+final class ParkManagerWebhostingModule extends AbstractParkManagerModule
 {
-    public function getContainerExtension(): DependencyExtension
-    {
-        if (null === $this->extension) {
-            $this->extension = new DependencyExtension();
-        }
-
-        return $this->extension;
-    }
-
     public function build(ContainerBuilder $container): void
     {
-        $mappings = [
-            realpath(__DIR__.'/Infrastructure/Doctrine/Account/Mapping') => 'ParkManager\Module\Webhosting\Domain\Account',
-            realpath(__DIR__.'/Infrastructure/Doctrine/DomainName/Mapping') => 'ParkManager\Module\Webhosting\Domain\DomainName',
-            realpath(__DIR__.'/Infrastructure/Doctrine/Package/Mapping') => 'ParkManager\Module\Webhosting\Domain\Package',
-            realpath(__DIR__.'/Infrastructure/Doctrine/RootMapping') => 'ParkManager\Module\Webhosting\Domain',
-        ];
+        parent::build($container);
 
-        $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings));
         $container->addCompilerPass(new CapabilitiesRegistryPass());
     }
 
@@ -70,5 +53,13 @@ final class ParkManagerWebhostingBundle extends Bundle
             $type = Type::getType('webhosting_capabilities');
             $type->setCapabilitiesFactory(null);
         }
+    }
+
+    protected function getDoctrineMappings(): array
+    {
+        $mapping = parent::getDoctrineMappings();
+        $mapping[realpath(__DIR__.'/Infrastructure/Doctrine/RootMapping')] = 'ParkManager\Module\Webhosting\Domain';
+
+        return $mapping;
     }
 }

--- a/src/Module/Webhosting/composer.json
+++ b/src/Module/Webhosting/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "park-manager/core-bundle": "^0.2"
+        "park-manager/core-bundle": "^0.3"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MPL-v2.0

Modules are expected to now implement the `ParkManagerModule` interface, an abstract class is provided to auto-wire Doctrine ORM Mapping, and enforce the DI Extension class alias.
But using the _old_ Bundle class/interface is still accepted.

The `ParkManagerModuleDependencyExtension` provides an addition on the Symfony Extension class making it much easier to load service files (from all supported types) and auto configuring Doctrine DBAL Types, templates, translations and routes. Traits are provided for highly custom Modules that don't use all these techniques, or want to load routes automatically.